### PR TITLE
Update to Cake 1.2.0

### DIFF
--- a/src/Cake.Issues.Reporting.Console.Tests/Cake.Issues.Reporting.Console.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Console.Tests/Cake.Issues.Reporting.Console.Tests.csproj
@@ -38,7 +38,7 @@
       <Version>1.0.0</Version>
     </PackageReference>
     <PackageReference Include="Cake.Testing">
-      <Version>1.0.0</Version>
+      <Version>1.2.0</Version>
     </PackageReference>
     <PackageReference Include="Shouldly">
       <Version>4.0.3</Version>

--- a/src/Cake.Issues.Reporting.Console/Cake.Issues.Reporting.Console.csproj
+++ b/src/Cake.Issues.Reporting.Console/Cake.Issues.Reporting.Console.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="1.2.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Issues" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Issues.Reporting" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Errata" Version="0.4.0" />

--- a/tests/frosting/net5.0/build/Build.csproj
+++ b/tests/frosting/net5.0/build/Build.csproj
@@ -5,7 +5,7 @@
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting" Version="1.1.0" />
+    <PackageReference Include="Cake.Frosting" Version="1.2.0" />
     <PackageReference Include="Cake.Issues" Version="1.0.0" />
     <PackageReference Include="Cake.Issues.Reporting" Version="1.0.0" />
     <PackageReference Include="Cake.Issues.Reporting.Console" Version="*-*" />


### PR DESCRIPTION
Update to Cake 1.2.0 which is required because of Spectre.Console dependency.