### PR TITLE
(GH-45) Multi-Target .NET Core 3.1, 5 & 6 instead of .NET Standard 2.0

### DIFF
--- a/nuspec/nuget/Cake.Frosting.Issues.Reporting.Console.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.Reporting.Console.nuspec
@@ -40,8 +40,14 @@ The addin requires Cake Frosting 1.2.0 or higher.
   </metadata>
   <files>
     <file src="icon.png" target="" />
-    <file src="..\..\src\Cake.Issues.Reporting.Console\bin\Release\netstandard2.0\Cake.Issues.Reporting.Console.dll" target="lib\netstandard2.0" />
-    <file src="..\..\src\Cake.Issues.Reporting.Console\bin\Release\netstandard2.0\Cake.Issues.Reporting.Console.pdb" target="lib\netstandard2.0" />
-    <file src="..\..\src\Cake.Issues.Reporting.Console\bin\Release\netstandard2.0\Cake.Issues.Reporting.Console.xml" target="lib\netstandard2.0" />
+    <file src="..\..\src\Cake.Issues.Reporting.Console\bin\Release\netcoreapp3.1\Cake.Issues.Reporting.Console.dll" target="lib\netcoreapp3.1" />
+    <file src="..\..\src\Cake.Issues.Reporting.Console\bin\Release\netcoreapp3.1\Cake.Issues.Reporting.Console.pdb" target="lib\netcoreapp3.1" />
+    <file src="..\..\src\Cake.Issues.Reporting.Console\bin\Release\netcoreapp3.1\Cake.Issues.Reporting.Console.xml" target="lib\netcoreapp3.1" />
+    <file src="..\..\src\Cake.Issues.Reporting.Console\bin\Release\net5.0\Cake.Issues.Reporting.Console.dll" target="lib\net5.0" />
+    <file src="..\..\src\Cake.Issues.Reporting.Console\bin\Release\net5.0\Cake.Issues.Reporting.Console.pdb" target="lib\net5.0" />
+    <file src="..\..\src\Cake.Issues.Reporting.Console\bin\Release\net5.0\Cake.Issues.Reporting.Console.xml" target="lib\net5.0" />
+    <file src="..\..\src\Cake.Issues.Reporting.Console\bin\Release\net6.0\Cake.Issues.Reporting.Console.dll" target="lib\net6.0" />
+    <file src="..\..\src\Cake.Issues.Reporting.Console\bin\Release\net6.0\Cake.Issues.Reporting.Console.pdb" target="lib\net6.0" />
+    <file src="..\..\src\Cake.Issues.Reporting.Console\bin\Release\net6.0\Cake.Issues.Reporting.Console.xml" target="lib\net6.0" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.Reporting.Console.nuspec
+++ b/nuspec/nuget/Cake.Issues.Reporting.Console.nuspec
@@ -32,9 +32,17 @@ The addin requires Cake 1.2.0 or higher.
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netstandard2.0/Cake.Issues.Reporting.Console.dll" target="lib\netstandard2.0" />
-    <file src="netstandard2.0/Cake.Issues.Reporting.Console.pdb" target="lib\netstandard2.0" />
-    <file src="netstandard2.0/Cake.Issues.Reporting.Console.xml" target="lib\netstandard2.0" />
-    <file src="netstandard2.0/Errata.dll" target="lib\netstandard2.0" />
+    <file src="netcoreapp3.1/Cake.Issues.Reporting.Console.dll" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1/Cake.Issues.Reporting.Console.pdb" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1/Cake.Issues.Reporting.Console.xml" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1/Errata.dll" target="lib\netcoreapp3.1" />
+    <file src="net5.0/Cake.Issues.Reporting.Console.dll" target="lib\net5.0" />
+    <file src="net5.0/Cake.Issues.Reporting.Console.pdb" target="lib\net5.0" />
+    <file src="net5.0/Cake.Issues.Reporting.Console.xml" target="lib\net5.0" />
+    <file src="net5.0/Errata.dll" target="lib\net5.0" />
+    <file src="net6.0/Cake.Issues.Reporting.Console.dll" target="lib\net6.0" />
+    <file src="net6.0/Cake.Issues.Reporting.Console.pdb" target="lib\net6.0" />
+    <file src="net6.0/Cake.Issues.Reporting.Console.xml" target="lib\net6.0" />
+    <file src="net6.0/Errata.dll" target="lib\net6.0" />
   </files>
 </package>

--- a/src/Cake.Issues.Reporting.Console/Cake.Issues.Reporting.Console.csproj
+++ b/src/Cake.Issues.Reporting.Console/Cake.Issues.Reporting.Console.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>Support for reporting issues to the console for the Cake.Issues addin for Cake Build Automation System</Description>
     <Authors>Pascal Berger</Authors>
     <Product>Cake.Issues</Product>


### PR DESCRIPTION
Multi-Target .NET Core 3.1, 5, & 6 to follow best-practices for Cake 2.0.

Fixes #45 