### PR TITLE
(GH-47) Fix exception if no issues are passed and ShowProviderSummary is enabled

### DIFF
--- a/src/Cake.Issues.Reporting.Console.Tests/ConsoleIssueReportGeneratorTests.cs
+++ b/src/Cake.Issues.Reporting.Console.Tests/ConsoleIssueReportGeneratorTests.cs
@@ -2,6 +2,8 @@
 {
     using Cake.Issues.Testing;
     using Cake.Testing;
+    using System.Collections.Generic;
+    using System.Linq;
     using Xunit;
 
     public sealed class ConsoleIssueReportGeneratorTests
@@ -37,14 +39,62 @@
 
         public sealed class TheInternalCreateReportMethod
         {
-            [Fact]
-            public void Should_Generate_Report()
+            public static IEnumerable<object[]> ReportFormatSettingsCombinations =>
+                from b1 in new[] { false, true }
+                from b2 in new[] { false, true }
+                from b3 in new[] { false, true }
+                from b4 in new[] { false, true }
+                from b5 in new[] { false, true }
+                select new object[] { b1, b2, b3, b4, b5 };
+
+            [Theory]
+            [MemberData(nameof(ReportFormatSettingsCombinations))]
+            public void Should_Generate_Report(
+                bool showDiagnostics,
+                bool compact,
+                bool groupByRule,
+                bool showProviderSummary,
+                bool showPrioritySummary)
             {
                 // Given
                 var fixture = new ConsoleIssueReportFixture();
+                fixture.ConsoleIssueReportFormatSettings.ShowDiagnostics = showDiagnostics;
+                fixture.ConsoleIssueReportFormatSettings.Compact = compact;
+                fixture.ConsoleIssueReportFormatSettings.GroupByRule = groupByRule;
+                fixture.ConsoleIssueReportFormatSettings.ShowProviderSummary = showProviderSummary;
+                fixture.ConsoleIssueReportFormatSettings.ShowPrioritySummary = showPrioritySummary;
 
                 // When
-                var logContents = fixture.CreateReport("Testfiles.issues.json", @"c:\Source\Cake.Issues.Reporting.Console");
+                var logContents =
+                    fixture.CreateReport(
+                        "Testfiles.issues.json",
+                        @"c:\Source\Cake.Issues.Reporting.Console");
+
+                // Then
+            }
+
+            [Theory]
+            [MemberData(nameof(ReportFormatSettingsCombinations))]
+            public void Should_Generate_Report_With_No_Issues(
+                bool showDiagnostics,
+                bool compact,
+                bool groupByRule,
+                bool showProviderSummary,
+                bool showPrioritySummary)
+            {
+                // Given
+                var fixture = new ConsoleIssueReportFixture();
+                fixture.ConsoleIssueReportFormatSettings.ShowDiagnostics = showDiagnostics;
+                fixture.ConsoleIssueReportFormatSettings.Compact = compact;
+                fixture.ConsoleIssueReportFormatSettings.GroupByRule = groupByRule;
+                fixture.ConsoleIssueReportFormatSettings.ShowProviderSummary = showProviderSummary;
+                fixture.ConsoleIssueReportFormatSettings.ShowPrioritySummary = showPrioritySummary;
+
+                // When
+                var logContents =
+                    fixture.CreateReport(
+                        new List<IIssue>(),
+                        @"c:\Source\Cake.Issues.Reporting.Console");
 
                 // Then
             }

--- a/src/Cake.Issues.Reporting.Console/ConsoleIssueReportGenerator.cs
+++ b/src/Cake.Issues.Reporting.Console/ConsoleIssueReportGenerator.cs
@@ -89,6 +89,12 @@
         /// <param name="issues">List of issues.</param>
         private void PrintSummary(IEnumerable<IIssue> issues)
         {
+            if (!issues.Any())
+            {
+                AnsiConsole.WriteLine("No issues");
+                return;
+            }
+
             AnsiConsole.WriteLine();
             AnsiConsole.WriteLine();
             var rule = new Rule("Summary").Centered();


### PR DESCRIPTION
Fixes an exception when drawing the provider summery bar chart if no issues are passed

Fixes #47