### PR TITLE
Don't restrict running on specific Cake major version 

### DIFF
--- a/nuspec/nuget/Cake.Frosting.Issues.Reporting.Console.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.Reporting.Console.nuspec
@@ -31,7 +31,7 @@ The addin requires Cake Frosting 1.2.0 or higher.
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues.Reporting.Console/releases/tag/2.0.0</releaseNotes>
     <dependencies>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="Cake.Core" version="[1.2,2.0)" exclude="Build,Analyzers" />
+        <dependency id="Cake.Core" version="3.0" exclude="Build,Analyzers" />
         <dependency id="Cake.Issues" version="[1.0,2.0)" exclude="Build,Analyzers" />
         <dependency id="Cake.Issues.Reporting" version="[1.0,2.0)" exclude="Build,Analyzers" />
         <dependency id="Errata" version="0.6.0" exclude="Build,Analyzers" />


### PR DESCRIPTION
Allows the addin for Cake Frosting to also run on future versions of Cake